### PR TITLE
test(e2e): pick datasets with an uploaded version, not v0 leftovers

### DIFF
--- a/e2e/dataset_test.go
+++ b/e2e/dataset_test.go
@@ -27,14 +27,14 @@ func TestDatasetList(t *testing.T) {
 	}
 }
 
-// TestDatasetStatusFirst lists datasets, takes the first Blob-type one, and
-// checks its status resolves a version and a download URL.
+// TestDatasetStatusFirst lists datasets, takes the first Blob-type one with
+// an uploaded version, and checks its status resolves a version and a download URL.
 func TestDatasetStatusFirst(t *testing.T) {
 	requireCreds(t)
 	list := runOK(t, "dataset", "list").combined()
 	id := firstIDOfType(list, "Blob")
 	if id == "" {
-		t.Skip("no Blob-type datasets on this instance to inspect")
+		t.Skip("no Blob-type datasets with an uploaded version on this instance to inspect")
 	}
 
 	res := runJH(t, "dataset", "status", id)
@@ -50,15 +50,15 @@ func TestDatasetStatusFirst(t *testing.T) {
 	}
 }
 
-// TestDatasetDownloadFirst lists datasets, takes the first Blob-type one,
-// downloads it to a temp path, and asserts the file was written and is
+// TestDatasetDownloadFirst lists datasets, takes the first Blob-type one
+// with an uploaded version, downloads it to a temp path, and asserts the file was written and is
 // non-empty.
 func TestDatasetDownloadFirst(t *testing.T) {
 	requireCreds(t)
 	list := runOK(t, "dataset", "list").combined()
 	id := firstIDOfType(list, "Blob")
 	if id == "" {
-		t.Skip("no Blob-type datasets on this instance to download")
+		t.Skip("no Blob-type datasets with an uploaded version on this instance to download")
 	}
 
 	dest := filepath.Join(t.TempDir(), "dataset.bin")
@@ -85,7 +85,7 @@ func TestDatasetStatusFirstBlobTree(t *testing.T) {
 	list := runOK(t, "dataset", "list").combined()
 	id := firstIDOfType(list, "BlobTree")
 	if id == "" {
-		t.Skip("no BlobTree-type datasets on this instance to inspect")
+		t.Skip("no BlobTree-type datasets with an uploaded version on this instance to inspect")
 	}
 
 	res := runJH(t, "dataset", "status", id)
@@ -107,7 +107,7 @@ func TestDatasetDownloadFirstBlobTree(t *testing.T) {
 	list := runOK(t, "dataset", "list").combined()
 	id := firstIDOfType(list, "BlobTree")
 	if id == "" {
-		t.Skip("no BlobTree-type datasets on this instance to download")
+		t.Skip("no BlobTree-type datasets with an uploaded version on this instance to download")
 	}
 
 	dest := filepath.Join(t.TempDir(), "dataset.bin")

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -76,30 +76,36 @@ func firstID(out string) string {
 }
 
 // firstIDOfType returns the ID of the first `dataset list` entry whose "Type:"
-// field equals dtype exactly (e.g. "Blob" does not match "BlobTree"). Blob and
+// field equals dtype exactly (e.g. "Blob" does not match "BlobTree") and that
+// has at least one uploaded version ("Version: v1" or higher). Blob and
 // BlobTree datasets have different download semantics (whole-blob URL vs
 // per-file), so type-specific tests must not depend on which type happens to
-// sort first on the instance.
+// sort first on the instance; and a "v0" entry (created but never uploaded)
+// has no version to inspect or download, so status/download fail on it by
+// design and it cannot drive a happy-path test.
 func firstIDOfType(out, dtype string) string {
 	typeRe := regexp.MustCompile(`(?m)^Type:\s*` + regexp.QuoteMeta(dtype) + `\s*$`)
+	verRe := regexp.MustCompile(`(?m)^Version:\s*v[1-9][0-9]*\s*$`)
 	ids := reIDLine.FindAllStringSubmatchIndex(out, -1)
 	for i, loc := range ids {
 		end := len(out)
 		if i+1 < len(ids) {
 			end = ids[i+1][0]
 		}
-		if typeRe.MatchString(out[loc[0]:end]) {
+		entry := out[loc[0]:end]
+		if typeRe.MatchString(entry) && verRe.MatchString(entry) {
 			return out[loc[2]:loc[3]]
 		}
 	}
 	return ""
 }
 
-// TestFirstIDOfType pins the listing-parse behaviour firstIDOfType relies on,
-// in particular that "Blob" does not match a "BlobTree" entry. Needs no
+// TestFirstIDOfType pins the listing-parse behaviour firstIDOfType relies on:
+// "Blob" does not match a "BlobTree" entry, and entries without an uploaded
+// version ("Version: v0", or no Version line at all) are skipped. Needs no
 // credentials — pure output parsing.
 func TestFirstIDOfType(t *testing.T) {
-	listing := "Found 3 dataset(s):\n" +
+	listing := "Found 4 dataset(s):\n" +
 		"\n" +
 		"ID: 0ba40730-c30d-460a-b5a4-bc1c2d3b6cbc\n" +
 		"Name: tree_first\n" +
@@ -110,15 +116,22 @@ func TestFirstIDOfType(t *testing.T) {
 		"Version: v1\n" +
 		"\n" +
 		"ID: 1a678f8f-a352-4554-a37c-1eee605e8aeb\n" +
-		"Name: blob_second\n" +
+		"Name: blob_empty_v0\n" +
+		"Size: 0 bytes\n" +
 		"Type: Blob\n" +
+		"Version: v0\n" +
 		"\n" +
 		"ID: 2ae31596-ef0c-4998-9362-7eb6b28688d4\n" +
-		"Name: blob_third\n" +
-		"Type: Blob\n"
+		"Name: blob_no_version_line\n" +
+		"Type: Blob\n" +
+		"\n" +
+		"ID: 3be31596-ef0c-4998-9362-7eb6b28688d4\n" +
+		"Name: blob_usable\n" +
+		"Type: Blob\n" +
+		"Version: v12\n"
 
-	if got := firstIDOfType(listing, "Blob"); got != "1a678f8f-a352-4554-a37c-1eee605e8aeb" {
-		t.Errorf("firstIDOfType(Blob) = %q, want the second entry (must not match BlobTree)", got)
+	if got := firstIDOfType(listing, "Blob"); got != "3be31596-ef0c-4998-9362-7eb6b28688d4" {
+		t.Errorf("firstIDOfType(Blob) = %q, want the last entry (must skip BlobTree, v0, and version-less entries)", got)
 	}
 	if got := firstIDOfType(listing, "BlobTree"); got != "0ba40730-c30d-460a-b5a4-bc1c2d3b6cbc" {
 		t.Errorf("firstIDOfType(BlobTree) = %q, want the first entry", got)


### PR DESCRIPTION
Fixes #55.

Since #54, the e2e dataset tests pick the first dataset **of the right type** from `jh dataset list` — but `firstIDOfType` never looks at the `Version:` line. On nightly-juliahub the first Blob in the UUID-ordered listing is a 0-byte `Version: v0` leftover (created by an integration test's CORS check that never uploads), so `TestDatasetStatusFirst`/`TestDatasetDownloadFirst` trip the CLI's own "no versions available for dataset" fail-fast — red every nightly since #54 merged (08-20, 08-21, 08-24).

Changes:
- `firstIDOfType` now also requires `Version: v[1-9][0-9]*` within the entry block, so only datasets with at least one uploaded version drive the happy-path tests. Applies to all four `*First`/`*FirstBlobTree` tests (a v0 BlobTree would misfire the same way).
- `TestFirstIDOfType` (credential-less parse pin) extended: a `Version: v0` entry and an entry with no `Version:` line must both be skipped.
- Skip messages/comments updated to say "with an uploaded version".

Verified: `go test -tags e2e -run TestFirstIDOfType ./e2e` passes; gofmt clean.
